### PR TITLE
2016 07 mkind pluginkey

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,5 +7,5 @@ setup(name='Splonebox Python Client',
       description='A client implementation to communicate with the splonebox core',
       install_requires=['pycrypto>=2.6.1', 'msgpack-python>=0.4.6'],
       author='bontric',
-      packages=['splonebox', 'splonebox.api', 'splonebox.rpc'],
+      packages=['splonebox', 'splonebox.api', 'splonebox.rpc', 'splonebox.os'],
       license='GNU Lesser General Public License v3')

--- a/splonebox/api/apicall.py
+++ b/splonebox/api/apicall.py
@@ -40,7 +40,6 @@ class ApiRegister(ApiCall):
         method, # "register" for obvious reasons
         [
             [                          # Metadata
-                <api key>,
                 <plugin name>,
                 <description>,
                 ...
@@ -62,7 +61,7 @@ class ApiRegister(ApiCall):
     def __init__(self, metadata: [], functions: []):
         """
         :param metadata: The Plugins Metadata:
-                    ["api_key", "name", "description", "author", "license"]
+                    ["name", "description", "author", "license"]
 
         :param functions: list of function descriptions
                     [[name,desc,[arg1,arg2..]], ...]
@@ -107,7 +106,7 @@ class ApiRun(ApiCall):
     method, # "run" for obvious reasons
         [
             [                          # Metadata
-                <(target) api_key>,
+                <(target) plugin_id>,
                 call_id
             ],
             <function name>,
@@ -166,16 +165,16 @@ class ApiRun(ApiCall):
 
         return call
 
-    def __init__(self, api_key: str, function_name: str, args: []):
+    def __init__(self, plugin_id: str, function_name: str, args: []):
         """
-        :param api_key: api_key of the plugin to be called
+        :param plugin_id: plugin identifier of the plugin to be called
         :param function_name: function wto be called
         :param args: list of arguments for the remote function
         :raises :InvalidApiCallError if the Information is invalid
         """
         super().__init__()
 
-        if not isinstance(api_key, str):
+        if not isinstance(plugin_id, str):
             raise InvalidApiCallError("plugin identifier has to be a string")
 
         if not isinstance(function_name, str):
@@ -190,12 +189,12 @@ class ApiRun(ApiCall):
 
         self.msg = MRequest()
         self.msg.function = "run"
-        self.msg.arguments = [[api_key, None], function_name, args]
+        self.msg.arguments = [[plugin_id, None], function_name, args]
 
     def get_method_args(self):
         return self.msg.arguments[2]
 
-    def get_api_key(self) -> str:
+    def get_plugin_id(self) -> str:
         return self.msg.arguments[0][0]
 
     def get_method_name(self) -> str:

--- a/splonebox/api/plugin.py
+++ b/splonebox/api/plugin.py
@@ -30,7 +30,6 @@ from splonebox.api.result import RunResult, Result, RegisterResult
 
 class Plugin:
     def __init__(self,
-                 api_key: str,
                  name: str,
                  desc: str,
                  author: str,
@@ -49,7 +48,7 @@ class Plugin:
         server's longterm key
         """
         # [<api_key>, <name>, <description>, <author>, <license>]
-        self._metadata = [api_key, name, desc, author, licence]
+        self._metadata = [name, desc, author, licence]
 
         self._rpc = MsgpackRpc()
         # register run function @ rpc dispatcher

--- a/splonebox/api/plugin.py
+++ b/splonebox/api/plugin.py
@@ -36,7 +36,6 @@ class Plugin:
                  licence: str,
                  debug=False):
         """
-        :param api_key: api key (make sure it was added to the core)
         :param name: Name of the plugin
         :param desc: Description of the plugin
         :param author: Author of the plugin
@@ -47,7 +46,7 @@ class Plugin:
         :param serverlongtermpk_path: path to file containing the
         server's longterm key
         """
-        # [<api_key>, <name>, <description>, <author>, <license>]
+        # [<name>, <description>, <author>, <license>]
         self._metadata = [name, desc, author, licence]
 
         self._rpc = MsgpackRpc()
@@ -126,17 +125,17 @@ class Plugin:
                 result.set_id(response.response[0])
                 self._results_pending[result.get_id()] = result
 
-    def run(self, api_key: str, function: str, arguments: []):
+    def run(self, plugin_id: str, function: str, arguments: []):
         """Run a remote function and return a :Result
 
         :param has_result: Does the called function have a result?
-        :param api_key: Targets api_key
+        :param plugin_id: Identifier of the plugin
         :param function: name of the function
         :param arguments: function arguments | empty list or None for no args
         :return: :RunResult
         :raises :RemoteRunError if run call failed
         """
-        run_call = ApiRun(api_key, function, arguments)
+        run_call = ApiRun(plugin_id, function, arguments)
         self._rpc.send(run_call.msg, self._handle_response)
 
         result = RunResult()

--- a/test/functional/test_complete_call.py
+++ b/test/functional/test_complete_call.py
@@ -36,7 +36,7 @@ class CompleteCall(unittest.TestCase):
 
         RemoteFunction(add)
 
-        plug = Plugin("abc", "foo", "bar", "bob", "alice")
+        plug = Plugin("foo", "bar", "bob", "alice")
 
         mock_send = mocks.rpc_connection_send(plug._rpc)
         result = plug.run("abc", "add", [7, 8])
@@ -44,7 +44,7 @@ class CompleteCall(unittest.TestCase):
         # receive request
         msg = MRequest.from_unpacked(msgpack.unpackb(mock_send.call_args[0][
             0]))
-        msg.arguments[0][0] = None  # remove api_key
+        msg.arguments[0][0] = None  # remove plugin id
         msg.arguments[0][1] = 123  # set call id
         plug._rpc._message_callback(msg.pack())
 
@@ -72,7 +72,7 @@ class CompleteCall(unittest.TestCase):
             pass
 
         RemoteFunction(fun)
-        plug = Plugin("abc", "foo", "bar", "bob", "alice")
+        plug = Plugin("foo", "bar", "bob", "alice")
         mock_send = mocks.rpc_connection_send(plug._rpc)
 
         result = plug.register(blocking=False)
@@ -82,7 +82,7 @@ class CompleteCall(unittest.TestCase):
         self.assertEqual(0, outgoing[0])
         self.assertEqual(b'register', outgoing[2])
         self.assertEqual(
-            [b"abc", b"foo", b"bar", b"bob", b"alice"], outgoing[3][0])
+            [b"foo", b"bar", b"bob", b"alice"], outgoing[3][0])
         self.assertIn([b'fun', b'', []], outgoing[3][1])
 
         # test response handling

--- a/test/functional/test_local_call.py
+++ b/test/functional/test_local_call.py
@@ -38,14 +38,14 @@ class LocalCall(unittest.TestCase):
 
         RemoteFunction(foo)
 
-        plug = Plugin("abc", "foo", "bar", "bob", "alice")
+        plug = Plugin("foo", "bar", "bob", "alice")
         mocks.plug_rpc_send(plug)  # ignore responses here
 
         mock_send = mocks.rpc_send(plug._rpc)
 
         # pretend that we received a message
         call = ApiRun("id", "foo", [True, b'hi', 5, -82, 7.23, "hi", 64])
-        call.msg.arguments[0][0] = None  # remove api_key
+        call.msg.arguments[0][0] = None  # remove plugin_id
         call.msg.arguments[0][1] = 123  # set some call id
         plug._rpc._message_callback(call.msg.pack())
 

--- a/test/functional/test_remote_calls.py
+++ b/test/functional/test_remote_calls.py
@@ -36,7 +36,7 @@ class RemoteCallTest(unittest.TestCase):
             pass
 
         RemoteFunction(fun2)
-        plug = Plugin("abc", "foo", "bar", "bob", "alice")
+        plug = Plugin("foo", "bar", "bob", "alice")
         mock_send = mocks.rpc_connection_send(plug._rpc)
 
         plug.register(blocking=False)
@@ -44,29 +44,28 @@ class RemoteCallTest(unittest.TestCase):
 
         self.assertEqual(0, outgoing[0])
         self.assertEqual(b'register', outgoing[2])
-        self.assertEqual(
-            [b"abc", b"foo", b"bar", b"bob", b"alice"], outgoing[3][0])
-        self.assertIn(
-            [b'fun2', b'', [False, b'', 3, -1, 2.0, b'', -1]], outgoing[3][1])
+        self.assertEqual([b"foo", b"bar", b"bob", b"alice"], outgoing[3][0])
+        self.assertIn([b'fun2', b'', [False, b'', 3, -1, 2.0, b'', -1]],
+                      outgoing[3][1])
 
         # cleanup remote_functions
         RemoteFunction.remote_functions = {}
 
     def test_run_functional(self):
-        plug = Plugin("abc", "foo", "bar", "bob", "alice")
+        plug = Plugin("foo", "bar", "bob", "alice")
         mock_send = mocks.rpc_connection_send(plug._rpc)
 
-        plug.run("api_key", "function", [1, "hi", 42.317, b'hi'])
+        plug.run("plugin_id", "function", [1, "hi", 42.317, b'hi'])
         outgoing = msgpack.unpackb(mock_send.call_args[0][0])
 
         self.assertEqual(0, outgoing[0])
         self.assertEqual(b'run', outgoing[2])
-        self.assertEqual([b'api_key', None], outgoing[3][0])
+        self.assertEqual([b'plugin_id', None], outgoing[3][0])
         self.assertEqual(b"function", outgoing[3][1])
         self.assertEqual([1, b'hi', 42.317, b'hi'], outgoing[3][2])
 
     def test_connect_functional(self):
-        plug = Plugin("abc", "foo", "bar", "bob", "alice")
+        plug = Plugin("foo", "bar", "bob", "alice")
 
         mock_sock = mocks.connection_socket(plug._rpc._connection)
         plug._rpc._connection.listen = Mock()

--- a/test/unit/test_apicall.py
+++ b/test/unit/test_apicall.py
@@ -78,7 +78,7 @@ class ApiCallTest(unittest.TestCase):
             ApiRun.from_msgpack_request(msg)
 
     def test_apiregister(self):
-        metadata = ["api_key", "plugin_name", "description", "MIT", "Guy"]
+        metadata = ["plugin_id", "plugin_name", "description", "MIT", "Guy"]
         functions = [["foo", "do_foo", [3, -1, 2.0, "", False, b'']]]
         call = ApiRegister(metadata, functions)
 
@@ -121,31 +121,30 @@ class ApiCallTest(unittest.TestCase):
         with self.assertRaises(InvalidApiCallError):
             ApiRegister(metadata, [["foo", 1, []]])
 
-
     def test_apirun(self):
-        api_key = "api_key"
+        plugin_id = "plugin_id"
         function_name = "name"
         args = [0]
 
-        call = ApiRun(api_key, function_name, args)
+        call = ApiRun(plugin_id, function_name, args)
         self.assertEqual(call.msg.function, "run")
-        self.assertEqual(call.get_api_key(), api_key)
+        self.assertEqual(call.get_plugin_id(), plugin_id)
         self.assertEqual(call.get_method_name(), function_name)
         self.assertEqual(call.get_method_args(), args)
-        self.assertEqual(call.msg.arguments, [[api_key, None], function_name,
+        self.assertEqual(call.msg.arguments, [[plugin_id, None], function_name,
                                               args])
 
         with self.assertRaises(InvalidApiCallError):
             ApiRun(2, function_name, args)
 
         with self.assertRaises(InvalidApiCallError):
-            ApiRun(api_key, 2, args)
+            ApiRun(plugin_id, 2, args)
 
         with self.assertRaises(InvalidApiCallError):
-            ApiRun(api_key, function_name, [None])
+            ApiRun(plugin_id, function_name, [None])
 
         with self.assertRaises(InvalidApiCallError):
-            ApiRun(api_key, function_name, [[]])
+            ApiRun(plugin_id, function_name, [[]])
 
         with self.assertRaises(InvalidApiCallError):
-            ApiRun(api_key, function_name, [object()])
+            ApiRun(plugin_id, function_name, [object()])

--- a/test/unit/test_plugin.py
+++ b/test/unit/test_plugin.py
@@ -28,7 +28,7 @@ from splonebox.api.remotefunction import RemoteFunction
 
 class PluginTest(unittest.TestCase):
     def test_register(self):
-        plug = Plugin("abc", "foo", "bar", "bob", "alice")
+        plug = Plugin("foo", "bar", "bob", "alice")
 
         rpc_send_mock = mocks.plug_rpc_send(plug)
         plug.register(blocking=False)
@@ -41,13 +41,13 @@ class PluginTest(unittest.TestCase):
         self.assertEqual(call_args.function, 'register')  # register request
 
         self.assertEqual(call_args.arguments[0],
-                         ['abc', 'foo', 'bar', 'bob', 'alice'])  # metadata
+                         ['foo', 'bar', 'bob', 'alice'])  # metadata
 
         self.assertEquals(
             len(call_args.arguments[1]), 0)  # no function registered
 
     def test_connect(self):
-        plug = Plugin("abc", "foo", "bar", "bob", "alice")
+        plug = Plugin("foo", "bar", "bob", "alice")
         connect_rpc_mock = mocks.plug_rpc_connect(plug)
 
         plug.connect("hostname", 1234)
@@ -55,23 +55,23 @@ class PluginTest(unittest.TestCase):
         # Note: connect is just a wrapper for Connection.connect()
 
     def test_run(self):
-        plug = Plugin("abc", "foo", "bar", "bob", "alice")
+        plug = Plugin("foo", "bar", "bob", "alice")
 
         rpc_send_mock = mocks.plug_rpc_send(plug)
 
-        plug.run("apikey", "foo", [1, "foo"])
+        plug.run("plugin_id", "foo", [1, "foo"])
         call_args = rpc_send_mock.call_args[0][0]
 
         self.assertEqual(call_args._type, 0)  # 0 indicates message request
         self.assertTrue(0 <= call_args._msgid < pow(2, 32))  # valid msgid
         self.assertEqual(call_args.function, 'run')  # run request
-        self.assertEqual(call_args.arguments[0][0], "apikey")
+        self.assertEqual(call_args.arguments[0][0], "plugin_id")
         self.assertEqual(call_args.arguments[1], "foo")
         self.assertEqual(call_args.arguments[2], [1, "foo"])
         pass
 
     def test_handle_run(self):
-        plug = Plugin("abc", "foo", "bar", "bob", "alice")
+        plug = Plugin("foo", "bar", "bob", "alice")
         send = mocks.plug_rpc_send(plug)  # catch results/responses
 
         mock = Mock()
@@ -111,7 +111,7 @@ class PluginTest(unittest.TestCase):
         RemoteFunction.remote_functions = {}
 
     def test_handle_response(self):
-        plug = Plugin("abc", "foo", "bar", "bob", "alice")
+        plug = Plugin("foo", "bar", "bob", "alice")
         send_mock = mocks.plug_rpc_send(plug)
 
         result = plug.register(blocking=False)


### PR DESCRIPTION
Remove api_key from register call and rename it everywhere to plugin_id.
- Change tests accordingly  

@mkind should be a quick review. If you have a moment It'd be great to get this done :octocat: 
